### PR TITLE
Remove redirect from MinecraftClientMixin

### DIFF
--- a/src/main/java/me/flourick/fvt/mixin/MinecraftClientMixin.java
+++ b/src/main/java/me/flourick/fvt/mixin/MinecraftClientMixin.java
@@ -251,12 +251,6 @@ abstract class MinecraftClientMixin
 		FVT_zAligned = false;
 	}
 
-	@Redirect(method = "handleInputEvents", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;dropSelectedItem(Z)Z", ordinal = 0))
-	private boolean onHandleDropSelectedItem(ClientPlayerEntity player, boolean entireStack)
-	{
-		return FVT.OPTIONS.freecam.getValueRaw() ? false : player.dropSelectedItem(entireStack);
-	}
-
 	@Inject(method = "handleInputEvents", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerInventory;selectedSlot:I", ordinal = 0, shift = At.Shift.BEFORE))
 	private void onHandleHotbarKeyPress(CallbackInfo info)
 	{


### PR DESCRIPTION
By not redirecting the call to `ClientPlayerEntity#dropSelectedItem`, the mod does not conflict with Interactic anymore, specifically gliscowo/interactic#5 is fixed